### PR TITLE
fix: add missing fields after import and only create rdf-URI-resource for actual URIs

### DIFF
--- a/src/main/java/no/fdk/dataservicecatalog/service/DcatApNoModelService.java
+++ b/src/main/java/no/fdk/dataservicecatalog/service/DcatApNoModelService.java
@@ -202,6 +202,13 @@ public class DcatApNoModelService {
             );
         }
 
+        if (dataService.getExternalDocs() != null && dataService.getExternalDocs().getUrl() != null && isURI(dataService.getExternalDocs().getUrl())) {
+            dataServiceResource.addProperty(
+                DCAT.landingPage,
+                ResourceFactory.createResource(URIref.encode(dataService.getExternalDocs().getUrl()))
+            );
+        }
+
         model.getProperty(URIref.encode(getCatalogUri(dataService.getOrganizationId())))
                 .addProperty(DCAT.service, dataServiceResource);
     }

--- a/src/main/java/no/fdk/dataservicecatalog/service/DcatApNoModelService.java
+++ b/src/main/java/no/fdk/dataservicecatalog/service/DcatApNoModelService.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static java.util.Map.entry;
+import static org.apache.jena.util.FileUtils.isURI;
 
 @Slf4j
 @Service
@@ -112,7 +113,7 @@ public class DcatApNoModelService {
 
         if (dataService.getTitle() != null) {
             dataService.getTitle().forEach((key, value) -> {
-                if (key != null && value != null) {
+                if (key != null && value != null && !value.isBlank()) {
                     dataServiceResource.addProperty(DCTerms.title, ResourceFactory.createLangLiteral(value, key));
                 }
             });
@@ -120,7 +121,7 @@ public class DcatApNoModelService {
 
         if (dataService.getDescription() != null) {
             dataService.getDescription().forEach((key, value) -> {
-                if (key != null && value != null) {
+                if (key != null && value != null && !value.isBlank()) {
                     dataServiceResource.addProperty(DCTerms.description, ResourceFactory.createLangLiteral(value, key));
                 }
             });
@@ -128,7 +129,7 @@ public class DcatApNoModelService {
 
         if (dataService.getEndpointDescriptions() != null) {
             dataService.getEndpointDescriptions().forEach(value -> {
-                if (value != null) {
+                if (value != null && isURI(value)) {
                     dataServiceResource.addProperty(DCAT.endpointDescription, ResourceFactory.createResource(URIref.encode(value)));
                 }
             });
@@ -136,7 +137,7 @@ public class DcatApNoModelService {
 
         if (dataService.getEndpointUrls() != null) {
             dataService.getEndpointUrls().forEach(value -> {
-                if (value != null) {
+                if (value != null && isURI(value)) {
                     dataServiceResource.addProperty(DCAT.endpointURL, ResourceFactory.createResource(URIref.encode(value)));
                 }
             });
@@ -148,19 +149,19 @@ public class DcatApNoModelService {
                     .addProperty(RDF.type, VCARD4.Organization)
                     .addProperty(VCARD4.fn, format("Contact information | (%s)", dataService.getOrganizationId()));
 
-            if (contact.getName() != null) {
+            if (contact.getName() != null && !contact.getName().isBlank()) {
                 contactPointResource.addProperty(VCARD4.hasOrganizationName, ResourceFactory.createLangLiteral(contact.getName(), "nb"));
             }
 
-            if (contact.getEmail() != null) {
+            if (contact.getEmail() != null && !contact.getEmail().isBlank()) {
                 contactPointResource.addProperty(VCARD4.hasEmail, ResourceFactory.createResource(URIref.encode(format("mailto:%s", contact.getEmail()))));
             }
 
-            if (contact.getUrl() != null) {
+            if (contact.getUrl() != null && isURI(contact.getUrl())) {
                 contactPointResource.addProperty(VCARD4.hasURL, ResourceFactory.createResource(URIref.encode(contact.getUrl())));
             }
 
-            if (contact.getPhone() != null) {
+            if (contact.getPhone() != null && !contact.getPhone().isBlank()) {
                 Resource telephoneResource = model.createResource()
                         .addProperty(RDF.type, VCARD4.TelephoneType)
                         .addProperty(VCARD4.hasValue, ResourceFactory.createResource(URIref.encode(format("tel:%s", contact.getPhone()))));
@@ -173,7 +174,7 @@ public class DcatApNoModelService {
 
         if (dataService.getMediaTypes() != null) {
             dataService.getMediaTypes().forEach(mediaType -> {
-                if (mediaType != null) {
+                if (mediaType != null && !mediaType.isBlank()) {
                     dataServiceResource.addProperty(
                         DCAT.mediaType,
                         ResourceFactory.createResource(URIref.encode(format("https://www.iana.org/assignments/media-types/%s", mediaType)))
@@ -184,7 +185,7 @@ public class DcatApNoModelService {
 
         if (dataService.getServesDataset() != null) {
             dataService.getServesDataset().forEach(dataset -> {
-                if (dataset != null) {
+                if (dataset != null && isURI(dataset)) {
                     dataServiceResource
                         .addProperty(
                             DCAT.servesDataset,
@@ -194,7 +195,7 @@ public class DcatApNoModelService {
             });
         }
 
-        if (dataService.getServiceType() != null) {
+        if (dataService.getServiceType() != null && !dataService.getServiceType().isBlank()) {
             dataServiceResource.addProperty(
                     DCTerms.conformsTo,
                     ResourceFactory.createResource(URIref.encode(format("https://data.norge.no/def/serviceType#%s", dataService.getServiceType())))


### PR DESCRIPTION
Hva backend svarer med etter importering av https://raw.githubusercontent.com/brreg/openAPI/master/specs/concept-cat.json:
````
{
    "created": "2020-08-31T12:09:03",
    "modified": "2020-08-31T12:09:03",
    "id": "5f4ccc3fcb85d36567cfcce1",
    "organizationId": "555111290",
    "title": {
        "nb": "National Concept Directory Search API"
    },
    "version": "0.1",
    "operationCount": 2,
    "contact": {
        "name": "Brønnøysundregistrene",
        "url": "https://fellesdatakatalog.brreg.no",
        "email": "fellesdatakatalog@brreg.no"
    },
    "endpointUrls": [
        "https://fellesdatakatalog.brreg.no/api/concepts"
    ],
    "description": {
        "nb": "Provides a basic search api against the National Concept Directory of Norway"
    },
    "endpointDescriptions": [
        "https://raw.githubusercontent.com/brreg/openAPI/master/specs/concept-cat.json"
    ],
    "license": {
        "name": "License of API",
        "url": "http://data.norge.no/nlod/no/2.0"
    },
    "status": "DRAFT",
    "externalDocs": {
        "description": "Dokumentasjon på Informasjonsforvaltning GitHub",
        "url": "https://informasjonsforvaltning.github.io/felles-datakatalog/begrepskatalog/api/"
    },
    "termsOfServiceUrl": "https://fellesdatakatalog.brreg.no/about",
    "imported": true
}
````